### PR TITLE
Optionally use rayon to (de)compress in paralllel

### DIFF
--- a/squish/Cargo.toml
+++ b/squish/Cargo.toml
@@ -15,4 +15,5 @@ travis-ci = {repository = "jansol/squish-rs"}
 
 [dependencies]
 libm = "0.1"
+rayon = {version = "1", optional = true}
 

--- a/squish/src/lib.rs
+++ b/squish/src/lib.rs
@@ -33,6 +33,8 @@ mod math;
 
 use crate::colourfit::{ClusterFit, ColourFit, RangeFit, SingleColourFit};
 use crate::colourset::ColourSet;
+#[cfg(feature="rayon")]
+use rayon::prelude::*;
 
 /// Defines a compression format
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -110,11 +112,15 @@ impl Format {
     /// * `output` - Space to store the decompressed image
     pub fn decompress(self, data: &[u8], width: usize, height: usize, output: &mut [u8]) {
         let blocks_wide = num_blocks(width);
-        let blocks_high = num_blocks(height);
         let block_size = self.block_size();
 
+        #[cfg(feature="rayon")]
+        let output_rows = output.par_chunks_mut(width * 4 * 4);
+        #[cfg(not(feature="rayon"))]
+        let output_rows = output.chunks_mut(width * 4 * 4);
+
         // loop over blocks
-        for y in 0..blocks_high {
+        output_rows.enumerate().for_each(|(y, output_row)| {
             for x in 0..blocks_wide {
                 // decompress the block
                 let bidx = (x + y * blocks_wide) * block_size;
@@ -125,17 +131,17 @@ impl Format {
                     for px in 0..4 {
                         // get target location
                         let sx = 4 * x + px;
-                        let sy = 4 * y + py;
+                        let sy = py;
 
                         if sx < width && sy < height {
                             for i in 0..4 {
-                                output[4 * (sx + sy * width) + i] = rgba[px + py * 4][i];
-                            }
+                                output_row[4 * (sx + sy * width) + i] = rgba[px + py * 4][i];
                         }
                     }
                 }
             }
         }
+        });
     }
 
     /// Returns how many bytes a 4x4 block of pixels will compress into
@@ -244,14 +250,20 @@ impl Format {
         assert!(output.len() >= self.compressed_size(width, height));
 
         let block_size = self.block_size();
-        let blocks_high = num_blocks(height);
+        // let blocks_high = num_blocks(height);
         let blocks_wide = num_blocks(width);
 
-        // loop over blocks, rounding size to next multiple of 4
-        for y in 0..blocks_high {
-            for x in 0..blocks_wide {
+        #[cfg(feature="rayon")]
+        let output_rows = output.par_chunks_mut(blocks_wide * block_size);
+        #[cfg(not(feature="rayon"))]
+        let output_rows = output.chunks_mut(blocks_wide * block_size);
+
+        output_rows.enumerate().for_each(|(y, output_row)| {
+            let mut source_rgba = [[0u8; 4]; 16];
+            let output_blocks = output_row.chunks_mut(block_size);
+
+            output_blocks.enumerate().for_each(|(x, output_block)| {
                 // build the 4x4 block of pixels
-                let mut source_rgba = [[0u8; 4]; 16];
                 let mut mask = 0u32;
                 for py in 0..4 {
                     for px in 0..4 {
@@ -273,12 +285,9 @@ impl Format {
                     }
                 }
 
-                // compress block into output
-                let offset = x * block_size + y * blocks_wide * block_size;
-                let block = &mut output[offset..offset + block_size];
-                self.compress_block_masked(source_rgba, mask, params, block);
-            }
-        }
+                self.compress_block_masked(source_rgba, mask, params, output_block);
+            });
+        });
     }
 }
 

--- a/squish/src/lib.rs
+++ b/squish/src/lib.rs
@@ -136,11 +136,11 @@ impl Format {
                         if sx < width && sy < height {
                             for i in 0..4 {
                                 output_row[4 * (sx + sy * width) + i] = rgba[px + py * 4][i];
+                            }
                         }
                     }
                 }
             }
-        }
         });
     }
 
@@ -250,7 +250,6 @@ impl Format {
         assert!(output.len() >= self.compressed_size(width, height));
 
         let block_size = self.block_size();
-        // let blocks_high = num_blocks(height);
         let blocks_wide = num_blocks(width);
 
         #[cfg(feature="rayon")]

--- a/squish_cli/Cargo.toml
+++ b/squish_cli/Cargo.toml
@@ -24,7 +24,10 @@ ddsfile = "0.2.3"
 jpeg-decoder = "0.1.15"
 png = "0.15.0"
 structopt = "0.3.2"
-rayon = "1.0"
+
+[features]
+rayon = ["squish/rayon"]
+default = ["rayon"]
 
 [dependencies.squish]
 path = "../squish"

--- a/squish_cli/src/main.rs
+++ b/squish_cli/src/main.rs
@@ -25,12 +25,10 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use ddsfile::{AlphaMode, D3D10ResourceDimension, D3DFormat, Dds, DxgiFormat};
-use squish::{Algorithm, Format, Params, COLOUR_WEIGHTS_PERCEPTUAL, num_blocks};
+use squish::{Algorithm, Format, Params, COLOUR_WEIGHTS_PERCEPTUAL};
 use structopt::StructOpt;
-use rayon::prelude::*;
 
 mod image;
-use image::RawImage;
 
 enum Profile {
     Speed,
@@ -131,8 +129,7 @@ fn compress_file(outfile: Option<PathBuf>, infile: &Path, format: Format, params
     };
 
     let mut buf = vec![0u8; format.compressed_size(image.width, image.height)];
-    parallel_compress(format, &image, &mut buf, params);
-    //format.compress(&image.data, image.width, image.height, params, &mut buf);
+    format.compress(&image.data, image.width, image.height, params, &mut buf);
 
     let alphamode = if format == Format::Bc1 {
         AlphaMode::PreMultiplied
@@ -186,45 +183,6 @@ fn decompress_file(outfile: Option<PathBuf>, infile: &Path) {
     format.decompress(&dds.data, width, height, &mut decompressed);
 
     image::png::write(&outfile, width as u32, height as u32, &decompressed);
-}
-
-fn parallel_compress(format: Format, image: &RawImage, buf: &mut [u8], params: Params) {
-    let block_size = format.block_size();
-    let blocks_wide = num_blocks(image.width);
-
-    // loop over blocks, rounding size to next multiple of 4
-    buf.par_chunks_mut(block_size)
-        .enumerate()
-        .for_each(|(i, b)| {
-            let x = i % blocks_wide;
-            let y = i / blocks_wide;
-            // build the 4x4 block of pixels
-            let mut source_rgba = [[0u8; 4]; 16];
-            let mut mask = 0u32;
-            for py in 0..4 {
-                for px in 0..4 {
-                    let index = 4 * py + px;
-
-                    // get position in source image
-                    let sx = 4 * x + px;
-                    let sy = 4 * y + py;
-
-                    // enable pixel if within bounds
-                    if sx < image.width && sy < image.height {
-                        // copy pixel value
-                        let src_index = 4 * (image.width * sy + sx);
-                            source_rgba[index].copy_from_slice(&image.data[src_index..src_index + 4]);
-
-                        // enable pixel
-                        mask |= 1 << index;
-                    }
-                }
-            }
-
-            // compress block into output
-            let block = &mut b[0..block_size];
-            format.compress_block_masked(source_rgba, mask, params, block);
-        });
 }
 
 impl FromStr for Profile {


### PR DESCRIPTION
Squish-cli implements a parallel compression algorithm using rayon.

This PR adds instead a compression and decompression implementation in the library itself which can be activated by using the rayon feature