### PR TITLE
Added Simple BC1 Unit Test

### DIFF
--- a/squish/src/lib.rs
+++ b/squish/src/lib.rs
@@ -333,4 +333,59 @@ mod tests {
         let estimate = Format::Bc3.compressed_size(15, 30);
         assert_eq!(estimate, 512);
     }
+
+    // The test-pattern is a gray-scale checkerboard of size 4x4 with 0xFF in the top-left.
+    // On top of that, the four middle pixels are set to 0x7F.
+    static DECODED_BLOCK_GRAY_4X4: &[u8] = &[
+        0xFF, 0x00, 0xFF, 0x00, // row 0
+        0x00, 0x7F, 0x7F, 0xFF, // row 1
+        0xFF, 0x7F, 0x7F, 0x00, // row 2
+        0x00, 0xFF, 0x00, 0xFF, // row 3
+    ];
+
+    fn decoded_block_gray_4x4_as_rgba() -> [u8; 4 * 4 * 4] {
+        let mut output = [0u8; 4 * 4 * 4];
+        for i in 0..DECODED_BLOCK_GRAY_4X4.len() {
+            output[i * 4 + 0] = DECODED_BLOCK_GRAY_4X4[i]; // R
+            output[i * 4 + 1] = DECODED_BLOCK_GRAY_4X4[i]; // G
+            output[i * 4 + 2] = DECODED_BLOCK_GRAY_4X4[i]; // B
+            output[i * 4 + 3] = 0xFF; //A
+        }
+        output
+    }
+
+    #[test]
+    fn test_bc1_decompression_gray() {
+        // BC1 data created with AMD Compressonator v4.1.5083
+        let encoded: [u8; 8] = [0x00, 0x00, 0xFF, 0xFF, 0x11, 0x68, 0x29, 0x44];
+        let mut output_actual = [0u8; 4 * 4 * 4];
+        Format::Bc1.decompress(&encoded, 4, 4, &mut output_actual);
+        assert_eq!(output_actual, decoded_block_gray_4x4_as_rgba());
+    }
+
+    #[test]
+    fn test_bc1_compression_gray_cluster_fit() {
+        fn test(algorithm: Algorithm) {
+            let mut output_actual = [0u8; 8];
+            Format::Bc1.compress(
+                &decoded_block_gray_4x4_as_rgba(),
+                4,
+                4,
+                Params {
+                    algorithm,
+                    weights: COLOUR_WEIGHTS_UNIFORM,
+                    weigh_colour_by_alpha: false,
+                },
+                &mut output_actual,
+            );
+            // BC1 data created with AMD Compressonator v4.1.5083
+            let output_expected = [0x00, 0x00, 0xFF, 0xFF, 0x11, 0x68, 0x29, 0x44];
+            assert_eq!(output_actual, output_expected);
+        }
+
+        // all algorithms should result in the same expected output
+        test(Algorithm::ClusterFit);
+        test(Algorithm::RangeFit);
+        test(Algorithm::IterativeClusterFit);
+    }
 }


### PR DESCRIPTION
This is a pretty simple pull request: I've added two tests that use the public compression and decompression functions.
It only tests a static "image" which is 4×4 pixels and validates the encoding/decoding result. The values for the expected results are taken from the [AMD Compressonator](https://github.com/GPUOpen-Tools/compressonator) v4.1.5083.

This pull request does *not* advance #2, as the offending blocks are not tested. This might be a good candidate for a future unit test addition.

A question about future development: is it the goal of this crate to create 100% the same results as [libsquish](https://sourceforge.net/projects/libsquish/)?
I mean: would it be possible to compare the output of libsquish directly to the output of this crate (and if its not the same, it is classified as a bug)? This could open up a possibility to compare random input to compression/decompression methods with the "reference" result of libsquish with the same input.