### PR TITLE
[Bugfix] Fixed Wrong Principle Component Calculation

### DIFF
--- a/squish/src/lib.rs
+++ b/squish/src/lib.rs
@@ -33,7 +33,7 @@ mod math;
 
 use crate::colourfit::{ClusterFit, ColourFit, RangeFit, SingleColourFit};
 use crate::colourset::ColourSet;
-#[cfg(feature = "rayon")]
+#[cfg(feature="rayon")]
 use rayon::prelude::*;
 
 /// Defines a compression format
@@ -114,9 +114,9 @@ impl Format {
         let blocks_wide = num_blocks(width);
         let block_size = self.block_size();
 
-        #[cfg(feature = "rayon")]
+        #[cfg(feature="rayon")]
         let output_rows = output.par_chunks_mut(width * 4 * 4);
-        #[cfg(not(feature = "rayon"))]
+        #[cfg(not(feature="rayon"))]
         let output_rows = output.chunks_mut(width * 4 * 4);
 
         // loop over blocks
@@ -252,9 +252,9 @@ impl Format {
         let block_size = self.block_size();
         let blocks_wide = num_blocks(width);
 
-        #[cfg(feature = "rayon")]
+        #[cfg(feature="rayon")]
         let output_rows = output.par_chunks_mut(blocks_wide * block_size);
-        #[cfg(not(feature = "rayon"))]
+        #[cfg(not(feature="rayon"))]
         let output_rows = output.chunks_mut(blocks_wide * block_size);
 
         output_rows.enumerate().for_each(|(y, output_row)| {

--- a/squish/src/lib.rs
+++ b/squish/src/lib.rs
@@ -364,7 +364,7 @@ mod tests {
     }
 
     #[test]
-    fn test_bc1_compression_gray_cluster_fit() {
+    fn test_bc1_compression_gray() {
         fn test(algorithm: Algorithm) {
             let mut output_actual = [0u8; 8];
             Format::Bc1.compress(
@@ -421,7 +421,7 @@ mod tests {
     }
 
     #[test]
-    fn test_bc1_compression_colour_cluster_fit() {
+    fn test_bc1_compression_colour() {
         fn test(algorithm: Algorithm) {
             let mut output_actual = [0u8; 8];
             Format::Bc1.compress(

--- a/squish/src/math.rs
+++ b/squish/src/math.rs
@@ -76,8 +76,8 @@ impl Sym3x3 {
         const POWER_ITERATION_COUNT: usize = 8;
 
         let row0 = Vec4::new(self.x[0], self.x[1], self.x[2], 0.0);
-        let row1 = Vec4::new(self.x[0], self.x[1], self.x[2], 0.0);
-        let row2 = Vec4::new(self.x[0], self.x[1], self.x[2], 0.0);
+        let row1 = Vec4::new(self.x[1], self.x[3], self.x[4], 0.0);
+        let row2 = Vec4::new(self.x[2], self.x[4], self.x[5], 0.0);
         let mut v = Vec4::new(1.0, 1.0, 1.0, 1.0);
 
         for _ in 0..POWER_ITERATION_COUNT {


### PR DESCRIPTION
The function for computing the principle component was not fully translated from the [original libsquish source](https://sourceforge.net/p/libsquish/code/HEAD/tree/trunk/maths.cpp#l235).

The indices in squish-rs are now set to the same values as libsquish.

A unit test has been added that indirectly checks this issue and should prevent any future regressions regarding this issue.
Fixes #2 .