### PR TITLE
Applied Rustfmt Formatting

### DIFF
--- a/squish/src/alpha.rs
+++ b/squish/src/alpha.rs
@@ -76,7 +76,13 @@ fn fix_range(min: &mut u8, max: &mut u8, steps: u8) {
     }
 }
 
-fn fit_codes(rgba: &[[u8; 4]; 16], channel: usize, mask: u32, codes: [u8; 8], indices: &mut [u8; 16]) -> u32 {
+fn fit_codes(
+    rgba: &[[u8; 4]; 16],
+    channel: usize,
+    mask: u32,
+    codes: [u8; 8],
+    indices: &mut [u8; 16],
+) -> u32 {
     let mut err = 0;
 
     // fit each alpha value to the codebook

--- a/squish/src/colourfit/cluster.rs
+++ b/squish/src/colourfit/cluster.rs
@@ -181,8 +181,7 @@ impl<'a> ColourFitImpl<'a> for ClusterFit<'a> {
             let mut part0 = zero;
             for i in 0..count {
                 // second cluster [i,j) is halfway along
-                let mut part1 =
-                    if i == 0 { self.points_weights[0] } else { zero };
+                let mut part1 = if i == 0 { self.points_weights[0] } else { zero };
                 let jmin = if i == 0 { 1 } else { i };
 
                 for j in jmin..=count {
@@ -313,11 +312,7 @@ impl<'a> ColourFitImpl<'a> for ClusterFit<'a> {
 
                 for j in i..=count {
                     // third cluster [j, k) is two thirds along
-                    let mut part2 = if j == 0 {
-                        self.points_weights[0]
-                    } else {
-                        zero
-                    };
+                    let mut part2 = if j == 0 { self.points_weights[0] } else { zero };
                     let kmin = if j == 0 { 1 } else { j };
 
                     for k in kmin..=count {

--- a/squish/src/lib.rs
+++ b/squish/src/lib.rs
@@ -33,7 +33,7 @@ mod math;
 
 use crate::colourfit::{ClusterFit, ColourFit, RangeFit, SingleColourFit};
 use crate::colourset::ColourSet;
-#[cfg(feature="rayon")]
+#[cfg(feature = "rayon")]
 use rayon::prelude::*;
 
 /// Defines a compression format
@@ -126,9 +126,9 @@ impl Format {
         let blocks_wide = num_blocks(width);
         let block_size = self.block_size();
 
-        #[cfg(feature="rayon")]
+        #[cfg(feature = "rayon")]
         let output_rows = output.par_chunks_mut(width * 4 * 4);
-        #[cfg(not(feature="rayon"))]
+        #[cfg(not(feature = "rayon"))]
         let output_rows = output.chunks_mut(width * 4 * 4);
 
         // loop over blocks
@@ -195,14 +195,14 @@ impl Format {
     ) {
         // compress alpha block(s)
         match self {
-            Format::Bc1 => {},
+            Format::Bc1 => {}
             Format::Bc2 => alpha::compress_bc2(&rgba, mask, &mut output[..8]),
             Format::Bc3 => alpha::compress_bc3(&rgba, 3, mask, &mut output[..8]),
             Format::Bc4 => alpha::compress_bc3(&rgba, 0, mask, &mut output[..8]),
             Format::Bc5 => {
                 alpha::compress_bc3(&rgba, 0, mask, &mut output[0..8]);
                 alpha::compress_bc3(&rgba, 1, mask, &mut output[8..16]);
-            },
+            }
         }
 
         // compress colour block if the format has one
@@ -229,8 +229,8 @@ impl Format {
                     let mut fit = ClusterFit::new(&colours, self, params.weights, iterate);
                     fit.compress(colour_block);
                 }
-            },
-            Format::Bc4 | Format::Bc5 => {},
+            }
+            Format::Bc4 | Format::Bc5 => {}
         }
     }
 
@@ -249,10 +249,10 @@ impl Format {
 
                 // decompress colour block
                 rgba = colourblock::decompress(colour_block, self == Format::Bc1);
-            },
+            }
             _ => {
                 rgba = [[0, 0, 0, 0xFF]; 16];
-            },
+            }
         }
 
         // decompress alpha block(s)
@@ -267,11 +267,11 @@ impl Format {
                     pixel[1] = pixel[0];
                     pixel[2] = pixel[0];
                 }
-            },
+            }
             Format::Bc5 => {
                 alpha::decompress_bc3(&mut rgba, 0, &block[..8]);
                 alpha::decompress_bc3(&mut rgba, 1, &block[8..16]);
-            },
+            }
         }
 
         rgba
@@ -298,9 +298,9 @@ impl Format {
         let block_size = self.block_size();
         let blocks_wide = num_blocks(width);
 
-        #[cfg(feature="rayon")]
+        #[cfg(feature = "rayon")]
         let output_rows = output.par_chunks_mut(blocks_wide * block_size);
-        #[cfg(not(feature="rayon"))]
+        #[cfg(not(feature = "rayon"))]
         let output_rows = output.chunks_mut(blocks_wide * block_size);
 
         output_rows.enumerate().for_each(|(y, output_row)| {

--- a/squish/src/math.rs
+++ b/squish/src/math.rs
@@ -97,7 +97,6 @@ impl Sym3x3 {
     }
 }
 
-
 pub fn f32_to_i32_clamped(a: f32, limit: i32) -> i32 {
     libm::roundf(a).max(0.0).min(limit as f32) as i32
 }

--- a/squish/src/math/vec4.rs
+++ b/squish/src/math/vec4.rs
@@ -104,7 +104,7 @@ impl Vec4 {
             libm::truncf(self.x),
             libm::truncf(self.y),
             libm::truncf(self.z),
-            libm::truncf(self.w)
+            libm::truncf(self.w),
         )
     }
 }

--- a/squish_cli/src/main.rs
+++ b/squish_cli/src/main.rs
@@ -147,7 +147,8 @@ fn compress_file(outfile: Option<PathBuf>, infile: &Path, format: Format, params
         false, // is_cubemap
         D3D10ResourceDimension::Texture2D,
         alphamode,
-    ).unwrap();
+    )
+    .unwrap();
     dds.data = buf;
 
     let mut outfile = File::create(outfile).expect("Failed to create output file");
@@ -245,6 +246,6 @@ fn parse_format(s: &str) -> Result<Format, &'static str> {
         "bc3" => Ok(Format::Bc3),
         "bc4" => Ok(Format::Bc4),
         "bc5" => Ok(Format::Bc5),
-        _ => Err("invalid compression format specifier")
+        _ => Err("invalid compression format specifier"),
     }
 }


### PR DESCRIPTION
After seeing the discussion in #8 about rustfmt, I simply ran it over all source files.
Some minor changes (mainly whitespace and comma) and line re-formatting happened.

Feel free to criticize the styling and I will try to find the appropriate settings for the `rustfmt.toml`.

Note: If adding CI to this library in the future, consider rejecting non-rustfmt formatted code.