### PR TITLE
Encoder and Decoder Traits as API

### DIFF
--- a/squish/src/bc1.rs
+++ b/squish/src/bc1.rs
@@ -1,0 +1,151 @@
+use crate::{colourblock, compress_bc1_bc2_bc3_colour_block, private, Decoder, Encoder, Params};
+
+pub struct BC1 {}
+
+impl private::Format for BC1 {
+    fn block_size() -> usize {
+        8
+    }
+}
+
+impl private::Decoder for BC1 {
+    fn decompress_block(block: &[u8]) -> [[u8; 4]; 16] {
+        use private::Format;
+        assert_eq!(block.len(), Self::block_size());
+        // decompress colour block
+        colourblock::decompress(block, true)
+    }
+}
+
+impl Decoder for BC1 {}
+
+impl private::Encoder for BC1 {
+    fn compress_block_masked(rgba: [[u8; 4]; 16], mask: u32, params: Params, output: &mut [u8]) {
+        compress_bc1_bc2_bc3_colour_block(rgba, mask, params, output, true)
+    }
+}
+
+impl Encoder for BC1 {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::*;
+
+    #[test]
+    fn test_storage_requirements() {
+        assert_eq!(BC1::compressed_size(16, 32), 256);
+        assert_eq!(BC1::compressed_size(15, 32), 256);
+    }
+
+    // The test-pattern is a gray-scale checkerboard of size 4x4 with 0xFF in the top-left.
+    // On top of that, the four middle pixels are set to 0x7F.
+    static DECODED_BLOCK_GRAY_4X4: &[u8] = &[
+        0xFF, 0x00, 0xFF, 0x00, // row 0
+        0x00, 0x7F, 0x7F, 0xFF, // row 1
+        0xFF, 0x7F, 0x7F, 0x00, // row 2
+        0x00, 0xFF, 0x00, 0xFF, // row 3
+    ];
+
+    fn decoded_block_gray_4x4_as_rgba() -> [u8; 4 * 4 * 4] {
+        let mut output = [0u8; 4 * 4 * 4];
+        for i in 0..DECODED_BLOCK_GRAY_4X4.len() {
+            output[i * 4 + 0] = DECODED_BLOCK_GRAY_4X4[i]; // R
+            output[i * 4 + 1] = DECODED_BLOCK_GRAY_4X4[i]; // G
+            output[i * 4 + 2] = DECODED_BLOCK_GRAY_4X4[i]; // B
+            output[i * 4 + 3] = 0xFF; //A
+        }
+        output
+    }
+
+    #[test]
+    fn test_bc1_decompression_gray() {
+        // BC1 data created with AMD Compressonator v4.1.5083
+        let encoded: [u8; 8] = [0x00, 0x00, 0xFF, 0xFF, 0x11, 0x68, 0x29, 0x44];
+        let mut output_actual = [0u8; 4 * 4 * 4];
+        BC1::decompress(&encoded, 4, 4, &mut output_actual);
+        assert_eq!(output_actual, decoded_block_gray_4x4_as_rgba());
+    }
+
+    #[test]
+    fn test_bc1_compression_gray() {
+        fn test(algorithm: Algorithm) {
+            let mut output_actual = [0u8; 8];
+            BC1::compress(
+                &decoded_block_gray_4x4_as_rgba(),
+                4,
+                4,
+                Params {
+                    algorithm,
+                    weights: COLOUR_WEIGHTS_UNIFORM,
+                    weigh_colour_by_alpha: false,
+                },
+                &mut output_actual,
+            );
+            // BC1 data created with AMD Compressonator v4.1.5083
+            let output_expected = [0x00, 0x00, 0xFF, 0xFF, 0x11, 0x68, 0x29, 0x44];
+            assert_eq!(output_actual, output_expected);
+        }
+
+        // all algorithms should result in the same expected output
+        test(Algorithm::ClusterFit);
+        test(Algorithm::RangeFit);
+        test(Algorithm::IterativeClusterFit);
+    }
+
+    // A colour test-pattern (RGB) with the first row in one colour,
+    // the second in another and the third and last row in a third colour.
+    static DECODED_BLOCK_COLOUR_4X4: &[u8] = &[
+        255, 150, 74, 255, 150, 74, 255, 150, 74, 255, 150, 74, // row 0
+        255, 120, 52, 255, 120, 52, 255, 120, 52, 255, 120, 52, // row 1
+        255, 105, 41, 255, 105, 41, 255, 105, 41, 255, 105, 41, // row 2
+        255, 105, 41, 255, 105, 41, 255, 105, 41, 255, 105, 41, // row 3
+    ];
+
+    // BC1 data created with AMD Compressonator v4.1.5083 and is the same as libsquish
+    static ENCODED_BLOCK_COLOUR_4X4: [u8; 8] = [0xA9, 0xFC, 0x45, 0xFB, 0x00, 0xFF, 0x55, 0x55];
+
+    fn decoded_block_colour_4x4_as_rgba() -> [u8; 4 * 4 * 4] {
+        let mut output = [0u8; 4 * 4 * 4];
+        for i in 0..4 * 4 {
+            output[i * 4 + 0] = DECODED_BLOCK_COLOUR_4X4[i * 3 + 0]; // R
+            output[i * 4 + 1] = DECODED_BLOCK_COLOUR_4X4[i * 3 + 1]; // G
+            output[i * 4 + 2] = DECODED_BLOCK_COLOUR_4X4[i * 3 + 2]; // B
+            output[i * 4 + 3] = 0xFF; //A
+        }
+        output
+    }
+
+    #[test]
+    fn test_bc1_decompression_colour() {
+        let encoded: [u8; 8] = ENCODED_BLOCK_COLOUR_4X4;
+        let mut output_actual = [0u8; 4 * 4 * 4];
+        BC1::decompress(&encoded, 4, 4, &mut output_actual);
+        assert_eq!(output_actual, decoded_block_colour_4x4_as_rgba());
+    }
+
+    #[test]
+    fn test_bc1_compression_colour() {
+        fn test(algorithm: Algorithm) {
+            let mut output_actual = [0u8; 8];
+            BC1::compress(
+                &decoded_block_colour_4x4_as_rgba(),
+                4,
+                4,
+                Params {
+                    algorithm,
+                    weights: COLOUR_WEIGHTS_UNIFORM,
+                    weigh_colour_by_alpha: false,
+                },
+                &mut output_actual,
+            );
+            let output_expected = ENCODED_BLOCK_COLOUR_4X4;
+            assert_eq!(output_actual, output_expected);
+        }
+
+        // all algorithms should result in the same expected output
+        test(Algorithm::ClusterFit);
+        test(Algorithm::RangeFit);
+        test(Algorithm::IterativeClusterFit);
+    }
+}

--- a/squish/src/bc2.rs
+++ b/squish/src/bc2.rs
@@ -1,0 +1,102 @@
+use crate::{
+    alpha, colourblock, compress_bc1_bc2_bc3_colour_block, private, Decoder, Encoder, Params,
+};
+
+pub struct BC2 {}
+
+impl private::Format for BC2 {
+    fn block_size() -> usize {
+        16
+    }
+}
+
+impl private::Decoder for BC2 {
+    fn decompress_block(block: &[u8]) -> [[u8; 4]; 16] {
+        use private::Format;
+        assert_eq!(block.len(), Self::block_size());
+        // decompress colour block
+        let mut rgba = colourblock::decompress(&block[8..16], true);
+        // decompress alpha block(s)
+        alpha::decompress_bc2(&mut rgba, &block[..8]);
+        rgba
+    }
+}
+
+impl Decoder for BC2 {}
+
+impl private::Encoder for BC2 {
+    fn compress_block_masked(rgba: [[u8; 4]; 16], mask: u32, params: Params, output: &mut [u8]) {
+        compress_bc1_bc2_bc3_colour_block(rgba, mask, params, output, false);
+
+        // compress alpha block(s)
+        alpha::compress_bc2(&rgba, mask, &mut output[..8]);
+    }
+}
+
+impl Encoder for BC2 {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::*;
+
+    #[test]
+    fn test_storage_requirements() {
+        assert_eq!(BC2::compressed_size(16, 32), 512);
+        assert_eq!(BC2::compressed_size(15, 32), 512);
+    }
+
+    // Same RGB colours as DECODED_BLOCK_COLOUR_4X4, with additional alpha channel.
+    // Alpha starts at 0x00, then increases by 0x11 for every pixel.
+    static DECODED_BLOCK_RGBA_4X4: &[u8] = &[
+        0xFF, 0x96, 0x4A, 0x00, 0xFF, 0x96, 0x4A, 0x11, // row 0, left half
+        0xFF, 0x96, 0x4A, 0x22, 0xFF, 0x96, 0x4A, 0x33, // row 0, right half
+        0xFF, 0x78, 0x34, 0x44, 0xFF, 0x78, 0x34, 0x55, // row 1, left half
+        0xFF, 0x78, 0x34, 0x66, 0xFF, 0x78, 0x34, 0x77, // row 1, right half
+        0xFF, 0x69, 0x29, 0x88, 0xFF, 0x69, 0x29, 0x99, // row 2, left half
+        0xFF, 0x69, 0x29, 0xAA, 0xFF, 0x69, 0x29, 0xBB, // row 2, right half
+        0xFF, 0x69, 0x29, 0xCC, 0xFF, 0x69, 0x29, 0xDD, // row 3, left half
+        0xFF, 0x69, 0x29, 0xEE, 0xFF, 0x69, 0x29, 0xFF, // row 3, right half
+    ];
+
+    // Combine the same alpha channel (BC2-compressed) with RGB from ENCODED_BLOCK_COLOUR_4X4.
+    // Alpha BC2 data created with GIMP DDS export.
+    static ENCODED_BC2_BLOCK_ALPHA_4X4: [u8; 16] = [
+        0x10, 0x32, 0x54, 0x76, 0x98, 0xBA, 0xDC, 0xFE, // Alpha
+        0xA9, 0xFC, 0x45, 0xFB, 0x00, 0xFF, 0x55, 0x55, // RGB block
+    ];
+
+    #[test]
+    fn test_bc2_decompression_colour() {
+        let encoded: [u8; 16] = ENCODED_BC2_BLOCK_ALPHA_4X4;
+        let mut output_actual = [0u8; 4 * 4 * 4];
+        BC2::decompress(&encoded, 4, 4, &mut output_actual);
+        let output_expected = DECODED_BLOCK_RGBA_4X4;
+        assert_eq!(output_actual, output_expected);
+    }
+
+    #[test]
+    fn test_bc2_compression_colour() {
+        fn test(algorithm: Algorithm) {
+            let mut output_actual = [0u8; 16];
+            BC2::compress(
+                &DECODED_BLOCK_RGBA_4X4,
+                4,
+                4,
+                Params {
+                    algorithm,
+                    weights: COLOUR_WEIGHTS_UNIFORM,
+                    weigh_colour_by_alpha: false,
+                },
+                &mut output_actual,
+            );
+            let output_expected = ENCODED_BC2_BLOCK_ALPHA_4X4;
+            assert_eq!(output_actual, output_expected);
+        }
+
+        // all algorithms should result in the same expected output
+        test(Algorithm::ClusterFit);
+        test(Algorithm::RangeFit);
+        test(Algorithm::IterativeClusterFit);
+    }
+}

--- a/squish/src/bc3.rs
+++ b/squish/src/bc3.rs
@@ -1,0 +1,47 @@
+use crate::{
+    alpha, colourblock, compress_bc1_bc2_bc3_colour_block, private, Decoder, Encoder, Params,
+};
+
+pub struct BC3 {}
+
+impl private::Format for BC3 {
+    fn block_size() -> usize {
+        16
+    }
+}
+
+impl private::Decoder for BC3 {
+    fn decompress_block(block: &[u8]) -> [[u8; 4]; 16] {
+        use private::Format;
+        assert_eq!(block.len(), Self::block_size());
+        // decompress colour block
+        let mut rgba = colourblock::decompress(&block[8..16], true);
+        // decompress alpha block(s)
+        alpha::decompress_bc3(&mut rgba, 3, &block[..8]);
+        rgba
+    }
+}
+
+impl Decoder for BC3 {}
+
+impl private::Encoder for BC3 {
+    fn compress_block_masked(rgba: [[u8; 4]; 16], mask: u32, params: Params, output: &mut [u8]) {
+        compress_bc1_bc2_bc3_colour_block(rgba, mask, params, output, false);
+
+        // compress alpha block(s)
+        alpha::compress_bc3(&rgba, 3, mask, &mut output[..8]);
+    }
+}
+
+impl Encoder for BC3 {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_storage_requirements() {
+        assert_eq!(BC3::compressed_size(16, 32), 512);
+        assert_eq!(BC3::compressed_size(15, 32), 512);
+    }
+}

--- a/squish/src/bc4.rs
+++ b/squish/src/bc4.rs
@@ -1,0 +1,47 @@
+use crate::{alpha, private, Decoder, Encoder, Params};
+
+pub struct BC4 {}
+
+impl private::Format for BC4 {
+    fn block_size() -> usize {
+        8
+    }
+}
+
+impl private::Decoder for BC4 {
+    fn decompress_block(block: &[u8]) -> [[u8; 4]; 16] {
+        use private::Format;
+        assert_eq!(block.len(), Self::block_size());
+        // decompress alpha
+        let mut rgba = [[0u8; 4]; 16];
+        alpha::decompress_bc3(&mut rgba, 0, &block[..8]);
+        // splat decompressed value into g and b channels
+        for ref mut pixel in rgba {
+            pixel[1] = pixel[0];
+            pixel[2] = pixel[0];
+        }
+        rgba
+    }
+}
+
+impl Decoder for BC4 {}
+
+impl private::Encoder for BC4 {
+    fn compress_block_masked(rgba: [[u8; 4]; 16], mask: u32, _params: Params, output: &mut [u8]) {
+        // compress alpha block(s)
+        alpha::compress_bc3(&rgba, 0, mask, &mut output[..8]);
+    }
+}
+
+impl Encoder for BC4 {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_storage_requirements() {
+        assert_eq!(BC4::compressed_size(16, 32), 256);
+        assert_eq!(BC4::compressed_size(15, 32), 256);
+    }
+}

--- a/squish/src/bc5.rs
+++ b/squish/src/bc5.rs
@@ -1,0 +1,44 @@
+use crate::{alpha, private, Decoder, Encoder, Params};
+
+pub struct BC5 {}
+
+impl private::Format for BC5 {
+    fn block_size() -> usize {
+        16
+    }
+}
+
+impl private::Decoder for BC5 {
+    fn decompress_block(block: &[u8]) -> [[u8; 4]; 16] {
+        use private::Format;
+        assert_eq!(block.len(), Self::block_size());
+        // decompress alpha
+        let mut rgba = [[0u8; 4]; 16];
+        alpha::decompress_bc3(&mut rgba, 0, &block[..8]);
+        alpha::decompress_bc3(&mut rgba, 1, &block[8..16]);
+        rgba
+    }
+}
+
+impl Decoder for BC5 {}
+
+impl private::Encoder for BC5 {
+    fn compress_block_masked(rgba: [[u8; 4]; 16], mask: u32, _params: Params, output: &mut [u8]) {
+        // compress alpha block(s)
+        alpha::compress_bc3(&rgba, 0, mask, &mut output[0..8]);
+        alpha::compress_bc3(&rgba, 1, mask, &mut output[8..16]);
+    }
+}
+
+impl Encoder for BC5 {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_storage_requirements() {
+        assert_eq!(BC5::compressed_size(16, 32), 512);
+        assert_eq!(BC5::compressed_size(15, 32), 512);
+    }
+}

--- a/squish/src/colourfit/cluster.rs
+++ b/squish/src/colourfit/cluster.rs
@@ -26,7 +26,7 @@ use core::f32;
 use crate::colourblock;
 use crate::colourset::ColourSet;
 use crate::math::{Sym3x3, Vec3, Vec4};
-use crate::{ColourWeights, Format};
+use crate::ColourWeights;
 
 use super::ColourFitImpl;
 
@@ -34,7 +34,7 @@ const MAX_ITERATIONS: usize = 8;
 
 pub struct ClusterFit<'a> {
     colourset: &'a ColourSet,
-    format: Format,
+    is_bc1: bool,
     weights: Vec4,
     num_iterations: usize,
     principle: Vec3,
@@ -48,13 +48,13 @@ pub struct ClusterFit<'a> {
 impl<'a> ClusterFit<'a> {
     pub fn new(
         colourset: &'a ColourSet,
-        format: Format,
+        is_bc1: bool,
         weights: ColourWeights,
         iterate: bool,
     ) -> Self {
         let mut fit = ClusterFit {
             colourset,
-            format,
+            is_bc1,
             weights: Vec4::new(weights[0], weights[1], weights[2], 1.0),
             num_iterations: if iterate { MAX_ITERATIONS } else { 1 },
             principle: Vec3::new(0.0, 0.0, 0.0),
@@ -138,7 +138,7 @@ impl<'a> ClusterFit<'a> {
 
 impl<'a> ColourFitImpl<'a> for ClusterFit<'a> {
     fn is_bc1(&self) -> bool {
-        self.format == Format::Bc1
+        self.is_bc1
     }
 
     fn is_transparent(&self) -> bool {

--- a/squish/src/colourfit/range.rs
+++ b/squish/src/colourfit/range.rs
@@ -25,13 +25,13 @@ use core::f32;
 use crate::colourblock;
 use crate::colourset::ColourSet;
 use crate::math::{Sym3x3, Vec3};
-use crate::{ColourWeights, Format};
+use crate::ColourWeights;
 
 use super::ColourFitImpl;
 
 pub struct RangeFit<'a> {
     colourset: &'a ColourSet,
-    format: Format,
+    is_bc1: bool,
     weights: Vec3,
     start: Vec3,
     end: Vec3,
@@ -41,10 +41,10 @@ pub struct RangeFit<'a> {
 }
 
 impl<'a> RangeFit<'a> {
-    pub fn new(colourset: &'a ColourSet, format: Format, weights: ColourWeights) -> Self {
+    pub fn new(colourset: &'a ColourSet, is_bc1: bool, weights: ColourWeights) -> Self {
         let mut fit = RangeFit {
             colourset,
-            format,
+            is_bc1,
             weights: Vec3::new(weights[0], weights[1], weights[2]),
             start: Vec3::new(0.0, 0.0, 0.0),
             end: Vec3::new(0.0, 0.0, 0.0),
@@ -145,7 +145,7 @@ impl<'a> RangeFit<'a> {
 
 impl<'a> ColourFitImpl<'a> for RangeFit<'a> {
     fn is_bc1(&self) -> bool {
-        self.format == Format::Bc1
+        self.is_bc1
     }
 
     fn is_transparent(&self) -> bool {

--- a/squish/src/colourfit/single.rs
+++ b/squish/src/colourfit/single.rs
@@ -25,14 +25,13 @@ use core::u32;
 use crate::colourblock;
 use crate::colourset::ColourSet;
 use crate::math::{f32_to_i32_clamped, Vec3};
-use crate::Format;
 
 use super::single_lut::*;
 use super::ColourFitImpl;
 
 pub struct SingleColourFit<'a> {
     colourset: &'a ColourSet,
-    format: Format,
+    is_bc1: bool,
     start: Vec3,
     end: Vec3,
     index: u8,
@@ -42,10 +41,10 @@ pub struct SingleColourFit<'a> {
 }
 
 impl<'a> SingleColourFit<'a> {
-    pub fn new(colourset: &'a ColourSet, format: Format) -> Self {
+    pub fn new(colourset: &'a ColourSet, is_bc1: bool) -> Self {
         SingleColourFit {
             colourset,
-            format,
+            is_bc1,
             start: Vec3::new(0.0, 0.0, 0.0),
             end: Vec3::new(0.0, 0.0, 0.0),
             index: 0,
@@ -108,7 +107,7 @@ impl<'a> SingleColourFit<'a> {
 
 impl<'a> ColourFitImpl<'a> for SingleColourFit<'a> {
     fn is_bc1(&self) -> bool {
-        self.format == Format::Bc1
+        self.is_bc1
     }
 
     fn is_transparent(&self) -> bool {

--- a/squish/src/colourset.rs
+++ b/squish/src/colourset.rs
@@ -21,7 +21,6 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 use crate::math::*;
-use crate::Format;
 
 pub struct ColourSet {
     count: usize,
@@ -32,7 +31,7 @@ pub struct ColourSet {
 }
 
 impl ColourSet {
-    pub fn new(rgba: &[[u8; 4]; 16], mask: u32, format: Format, alpha_weighted: bool) -> ColourSet {
+    pub fn new(rgba: &[[u8; 4]; 16], mask: u32, is_bc1: bool, alpha_weighted: bool) -> ColourSet {
         let mut set = ColourSet {
             count: 0,
             points: [Vec3::new(0f32, 0f32, 0f32); 16],
@@ -51,7 +50,7 @@ impl ColourSet {
             }
 
             // DXT uses binary alpha
-            if (format == Format::Bc1) && (rgba[i][3] < 128u8) {
+            if (is_bc1) && (rgba[i][3] < 128u8) {
                 set.remap[i] = -1;
                 set.transparent = true;
                 continue;
@@ -85,7 +84,7 @@ impl ColourSet {
                     && (rgba[i][0] == rgba[j][0])
                     && (rgba[i][1] == rgba[j][1])
                     && (rgba[i][2] == rgba[j][2])
-                    && (format != Format::Bc1 || rgba[j][3] >= 128u8);
+                    && (!is_bc1 || rgba[j][3] >= 128u8);
                 if duplicate {
                     // get index of duplicate
                     let index = set.remap[j];

--- a/squish/src/lib.rs
+++ b/squish/src/lib.rs
@@ -38,6 +38,7 @@ use rayon::prelude::*;
 
 /// Defines a compression format
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum Format {
     Bc1,
     Bc2,

--- a/squish_cli/src/main.rs
+++ b/squish_cli/src/main.rs
@@ -216,6 +216,7 @@ fn format_to_dxgiformat(f: Format) -> DxgiFormat {
         Format::Bc3 => DxgiFormat::BC3_UNorm_sRGB,
         Format::Bc4 => DxgiFormat::BC4_UNorm,
         Format::Bc5 => DxgiFormat::BC5_UNorm,
+        _ => panic!("Unsupported BC format!"),
     }
 }
 


### PR DESCRIPTION
As discussed in jansol/texpresso#3, the `Format` enum is made non-exhaustive, forcing users of the crate to consider the case that an unknown format arises.